### PR TITLE
standardize naming for struct constructors

### DIFF
--- a/internal/apihandler.go
+++ b/internal/apihandler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-playground/validator/v10"
 )
 
-func ConstructHandler(service api.Service) *ApiHandler {
+func NewApiHandler(service api.Service) *ApiHandler {
 	var propsFields []string
 	for _, field := range reflect.VisibleFields(reflect.TypeOf(api.AlbumPropertiesDTO{})) {
 		propsFields = append(propsFields, field.Name)

--- a/internal/apihandler_test.go
+++ b/internal/apihandler_test.go
@@ -339,7 +339,7 @@ func InitHandlerWithMocks() (api.Handler, *MockService, *gin.Context, *httptest.
 	respWriter := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(respWriter)
 	service := new(MockService)
-	handler := ConstructHandler(service)
+	handler := NewApiHandler(service)
 	return handler, service, context, respWriter
 }
 

--- a/internal/inmemoryservice.go
+++ b/internal/inmemoryservice.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func ConstructInMemoryService(idGen api.IdGenerator) *InMemoryService {
+func NewInMemoryService(idGen api.IdGenerator) *InMemoryService {
 	return &InMemoryService{
 		Albums: []api.Album{},
 		IdGen:  idGen,

--- a/internal/inmemoryservice_test.go
+++ b/internal/inmemoryservice_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func InitServiceWithMocks() api.Service {
-	idGen := ConstructXidGenerator()
-	service := ConstructInMemoryService(idGen)
+	idGen := NewXidGenerator()
+	service := NewInMemoryService(idGen)
 	return service
 }
 

--- a/internal/xidgenerator.go
+++ b/internal/xidgenerator.go
@@ -2,7 +2,7 @@ package internal
 
 import "github.com/rs/xid"
 
-func ConstructXidGenerator() *XidGenerator {
+func NewXidGenerator() *XidGenerator {
 	return &XidGenerator{}
 }
 

--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 var startTime time.Time = time.Now()
 
 func main() {
-	idGenerator := internal.ConstructXidGenerator()
-	service := internal.ConstructInMemoryService(idGenerator)
-	handler := internal.ConstructHandler(service)
+	idGenerator := internal.NewXidGenerator()
+	service := internal.NewInMemoryService(idGenerator)
+	handler := internal.NewApiHandler(service)
 	router := initRouter(handler)
 
 	router.Run(":8080")


### PR DESCRIPTION
### Test Plan
- [x] `go test -cover ./...`
```
?       andrewsaputra/go-rest-sample/api        [no test files]
ok      andrewsaputra/go-rest-sample    (cached)        coverage: 72.2% of statements
ok      andrewsaputra/go-rest-sample/internal   0.011s  coverage: 100.0% of statements
```